### PR TITLE
Rudimentary SIGINT handling

### DIFF
--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -1,16 +1,6 @@
 //! This module provides the `TestCaseRunner` and `TestCase` trait for running and defining test cases.
 //! It handles setup, execution, and cleanup of test environments.
 
-use std::{
-    panic::{self},
-    path::{Path, PathBuf},
-    time::Duration,
-};
-
-use anyhow::{bail, Context};
-use async_trait::async_trait;
-use futures::FutureExt;
-
 use super::{
     config::{
         default_rollup_config, BitcoinConfig, FullBatchProverConfig, FullFullNodeConfig,
@@ -29,6 +19,15 @@ use crate::{
     traits::NodeT,
     utils::{get_default_genesis_path, get_workspace_root},
 };
+use anyhow::{bail, Context};
+use async_trait::async_trait;
+use futures::FutureExt;
+use std::{
+    panic::{self},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tokio::signal;
 
 // TestCaseRunner manages the lifecycle of a test case, including setup, execution, and cleanup.
 /// It creates a test framework with the associated configs, spawns required nodes, connects them,
@@ -83,10 +82,19 @@ impl<T: TestCase> TestCaseRunner<T> {
     /// This sets up the framework, executes the test, and ensures cleanup is performed even if a panic occurs.
     pub async fn run(mut self) -> Result<()> {
         let mut framework = None;
+
         let result = panic::AssertUnwindSafe(async {
-            framework = Some(TestFramework::new(Self::generate_test_config()?).await?);
-            let f = framework.as_mut().unwrap();
-            self.run_test_case(f).await
+            tokio::select! {
+                res = async {
+                    framework = Some(TestFramework::new(Self::generate_test_config()?).await?);
+                    let f = framework.as_mut().unwrap();
+                    self.run_test_case(f).await
+                 } => res,
+                _ = signal::ctrl_c() => {
+                    println!("Initiating shutdown...");
+                    bail!("Shutdown received before completion")
+                }
+            }
         })
         .catch_unwind()
         .await;


### PR DESCRIPTION
- Make sure to cleanup processes when receiving SIGNINT.
- This is rudimentary and does not correctly addresses partial framework inialization. It should already alleviates the issue in most normal use cases.

- Partially fixes #24 