### PR TITLE
Modify arguments for sequencer and prover config path

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -89,7 +89,7 @@ impl<C: Config + LogPathProvider> Node<C> {
                 kind => kind.to_string(),
             };
             Ok(vec![
-                format!("--{node_kind_str}-config-path"),
+                format!("--{node_kind_str}"),
                 config_path.display().to_string(),
             ])
         })


### PR DESCRIPTION
As with https://github.com/chainwayxyz/citrea/pull/1320, `--sequencer-config-path` and `--prover-config-path` options are renamed to `--sequencer` and `--prover`. `get_node_config_args` is modified to comply with the changes.