### PR TITLE
Expose da client per Node

### DIFF
--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -51,6 +51,14 @@ impl TestCase for DockerIntegrationTest {
 
         assert_eq!(commitments.len(), 1);
 
+        let unspent_sequencer = sequencer
+            .da
+            .list_unspent(None, None, None, None, None)
+            .await?;
+        let unspent_da = da.list_unspent(None, None, None, None, None).await?;
+        // Make sure sequencer.da and da don't hit the same wallet
+        assert_ne!(unspent_sequencer, unspent_da);
+
         Ok(())
     }
 }


### PR DESCRIPTION
- Expose `BitcoinClient` per citrea node which targets nodes' wallet endpoint.
- Should be used for wallet querying needs, such as `listunspent` per node, etc