### PR TITLE
set ALL_CRATES=info for tracing subscriber

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -163,10 +163,7 @@ where
         let kind = Self::node_kind();
         self.node_config().map(|_| {
             let config_path = dir.join(format!("{kind}_config.toml"));
-            let node_kind_str = match &kind {
-                NodeKind::BatchProver | NodeKind::LightClientProver => "prover".to_string(),
-                kind => kind.to_string(),
-            };
+            let node_kind_str = kind.to_string();
             vec![
                 format!("--{node_kind_str}"),
                 config_path.display().to_string(),

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -494,7 +494,7 @@ static INIT: Once = Once::new();
 fn setup_logging() {
     INIT.call_once(|| {
         let env_filter = EnvFilter::try_from_default_env()
-            .or_else(|_| EnvFilter::try_new("citrea_e2e=info"))
+            .or_else(|_| EnvFilter::try_new("info"))
             .unwrap();
 
         if std::env::var("JSON_LOGS").is_ok() {


### PR DESCRIPTION
Before logs for only `citrea_e2e` were shown, the other we suppressed. Now we can see:

```
2024-10-29T23:35:37.357640Z ERROR panic: thread 'bitcoin_e2e::sequencer_commitments::test_sequencer_sends_commitments_to_da_layer' panicked at 'assertion `left == right` failed
  left: 1
 right: 3': bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs:193
   0: <backtrace::capture::Backtrace as core::default::Default>::default
             at /home/kpp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.73/src/capture.rs:422:9
   1: log_panics::Config::install_panic_hook::{{closure}}
             at /home/kpp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/log-panics-2.1.0/src/lib.rs:115:29
   2: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/alloc/src/boxed.rs:2036:9
      std::panicking::rust_panic_with_hook
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:799:13
   3: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:664:13
   4: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:171:18
   5: rust_begin_unwind
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:652:5
   6: core::panicking::panic_fmt
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:72:14
   7: core::panicking::assert_failed_inner
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:409:17
   8: core::panicking::assert_failed
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:364:5
   9: <all_tests::bitcoin_e2e::sequencer_commitments::SequencerSendCommitmentsToDaTest as citrea_e2e::test_case::TestCase>::run_test::{{closure}}
             at /home/kpp/chainway/secret-sovereign-sdk/bin/citrea/tests/bitcoin_e2e/sequencer_commitments.rs:193:9
  10: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/future/future.rs:123:9
  11: citrea_e2e::test_case::TestCaseRunner<T>::run_test_case::{{closure}}
             at /home/kpp/chainway/citrea-e2e/src/test_case.rs:72:28
  12: citrea_e2e::test_case::TestCaseRunner<T>::run::{{closure}}::{{closure}}::{{closure}}
             at /home/kpp/chainway/citrea-e2e/src/test_case.rs:86:43
  13: citrea_e2e::test_case::TestCaseRunner<T>::run::{{closure}}::{{closure}}::{{closure}}
             at /home/kpp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.3/src/macros/select.rs:557:49
  14: <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /home/kpp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.3/src/future/poll_fn.rs:58:9
  15: citrea_e2e::test_case::TestCaseRunner<T>::run::{{closure}}::{{closure}}
             at /home/kpp/chainway/citrea-e2e/src/test_case.rs:82:13
...
```
