### PR TITLE
Create a dir per node restart

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -129,6 +129,10 @@ where
         &self.dir
     }
 
+    fn set_dir(&mut self, new_dir: PathBuf) {
+        self.dir = new_dir
+    }
+
     fn rpc_bind_host(&self) -> &str {
         &self.rollup.rpc.bind_host
     }


### PR DESCRIPTION
- Create a new directory on each restart in order not to overwrite the previous one.
- Prevents log from being overwritten