### PR TITLE
update finality depth

### DIFF
--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -24,7 +24,7 @@ use super::{
 };
 use crate::{log_provider::LogPathProvider, node::NodeKind};
 
-pub const FINALITY_DEPTH: u64 = 30;
+pub const DEFAULT_FINALITY_DEPTH: u64 = 5;
 
 pub struct BitcoinNode {
     spawn_output: SpawnOutput,
@@ -98,8 +98,8 @@ impl BitcoinNode {
         Ok(())
     }
 
-    pub async fn get_finalized_height(&self) -> Result<u64> {
-        Ok(self.get_block_count().await? - FINALITY_DEPTH + 1)
+    pub async fn get_finalized_height(&self, finality_depth: Option<u64>) -> Result<u64> {
+        Ok(self.get_block_count().await? - finality_depth.unwrap_or(DEFAULT_FINALITY_DEPTH) + 1)
     }
 
     async fn wait_for_shutdown(&self) -> Result<()> {

--- a/tests/docker.rs
+++ b/tests/docker.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use bitcoincore_rpc::RpcApi;
 use citrea_e2e::{
-    bitcoin::FINALITY_DEPTH,
+    bitcoin::DEFAULT_FINALITY_DEPTH,
     config::{TestCaseConfig, TestCaseDockerConfig},
     framework::TestFramework,
     test_case::{TestCase, TestCaseRunner},
@@ -40,8 +40,8 @@ impl TestCase for DockerIntegrationTest {
         // Wait for blob inscribe tx to be in mempool
         da.wait_mempool_len(1, None).await?;
 
-        da.generate(FINALITY_DEPTH).await?;
-        let finalized_height = da.get_finalized_height().await?;
+        da.generate(DEFAULT_FINALITY_DEPTH).await?;
+        let finalized_height = da.get_finalized_height(None).await?;
 
         batch_prover
             .wait_for_l1_height(finalized_height, None)


### PR DESCRIPTION
Updates default finality depth to 5, which will match the pr that I am working on in citrea repo, which will make FINALITY_DEPTH=5 if testing feature is enabled. But still wanted to add the capability to pass a custom depth in case some tests ever need to be run without a testing feature.