### PR TITLE
Fix rpc port assignment

### DIFF
--- a/src/framework.rs
+++ b/src/framework.rs
@@ -322,8 +322,8 @@ fn generate_test_config<T: TestCase>(
         std::fs::create_dir_all(&data_dir)
             .with_context(|| format!("Failed to create {} directory", data_dir.display()))?;
 
-        let p2p_port = get_available_port()?;
         let rpc_port = get_available_port()?;
+        let p2p_port = get_available_port()?;
 
         bitcoin_confs.push(BitcoinConfig {
             p2p_port,


### PR DESCRIPTION
- Fix port assignment since v29.

Behaviour changed with :
```
- When the `-port` configuration option is used, the default onion listening port will now
be derived to be that port + 1 instead of being set to a fixed value (8334 on mainnet).
This re-allows setups with multiple local nodes using different `-port` and not using `-bind`,
which would lead to a startup failure in v28.0 due to a port collision.
Note that a `HiddenServicePort` manually configured in `torrc` may need adjustment if used in
connection with the `-port` option.
For example, if you are using `-port=5555` with a non-standard value and not using `-bind=...=onion`,
previously Bitcoin Core would listen for incoming Tor connections on `127.0.0.1:8334`.
Now it would listen on `127.0.0.1:5556` (`-port` plus one). If you configured the hidden service manually
in torrc now you have to change it from `HiddenServicePort 8333 127.0.0.1:8334` to `HiddenServicePort 8333
127.0.0.1:5556`, or configure bitcoind with `-bind=127.0.0.1:8334=onion` to get the previous behavior.
(#31223)
```

But that conflicted with our rpc port assignment.
Ideal fix would be for bitcoin not to use this +1 port when running with `-noonion` or `-onion=0` but that's not the case for now.
Switching up the assignment and set rpc_port first so that it doesn't conflict with the automatic port assignement from bitcoin