### PR TITLE
Remove NodeCluster take method

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -383,15 +383,6 @@ where
         self.inner.get(index)
     }
 
-    pub fn take(mut self, index: usize) -> (Self, Option<Node<C>>) {
-        if index < self.inner.len() {
-            let node = Some(self.inner.remove(index));
-            (self, node)
-        } else {
-            (self, None)
-        }
-    }
-
     #[allow(unused)]
     pub fn get_mut(&mut self, index: usize) -> Option<&mut Node<C>> {
         self.inner.get_mut(index)

--- a/src/node.rs
+++ b/src/node.rs
@@ -391,6 +391,10 @@ where
     pub fn iter(&self) -> std::slice::Iter<'_, Node<C>> {
         self.inner.iter()
     }
+
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, Node<C>> {
+        self.inner.iter_mut()
+    }
 }
 
 impl NodeCluster<SequencerConfig> {


### PR DESCRIPTION
- Replace with iter_mut for same access pattern without consuming the option (which prevent shutting down the node)