### PR TITLE
Reduce wait_mempool_len default timeout to 30s

### DIFF
--- a/src/bitcoin.rs
+++ b/src/bitcoin.rs
@@ -66,7 +66,7 @@ impl BitcoinNode {
         target_len: usize,
         timeout: Option<Duration>,
     ) -> Result<()> {
-        let timeout = timeout.unwrap_or(Duration::from_secs(300));
+        let timeout = timeout.unwrap_or(Duration::from_secs(30));
         let start = Instant::now();
         while start.elapsed() < timeout {
             let mempool_len = self.get_raw_mempool().await?.len();


### PR DESCRIPTION
- This is reduced from 5min to 30s to have faster failure/feedback.
This was set to 300s originally before we did nonce mining improvements. Nonce mining with short prefix is almost instant and full flow should rarely require more than 30s. If ever, there's still the option to override default timeout behaviour on the odd cases that require it

Fixes #135 