### PR TITLE
feat: Add config to keep citrean and bitcoin nodes alive on shutdown

### DIFF
--- a/src/config/test_case.rs
+++ b/src/config/test_case.rs
@@ -81,6 +81,7 @@ pub struct TestCaseConfig {
     pub clementine_dir: Option<String>,
     pub test_id: String,
     pub mode: CitreaMode,
+    pub stop_nodes_on_exit: bool,
 }
 
 impl Default for TestCaseConfig {
@@ -112,6 +113,7 @@ impl Default for TestCaseConfig {
             clementine_dir: None,
             test_id,
             mode: CitreaMode::Dev,
+            stop_nodes_on_exit: true,
         }
     }
 }

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -299,7 +299,12 @@ impl TestFramework {
     }
 
     pub async fn stop(&mut self) -> Result<()> {
-        info!("Stopping framework...");
+        if !self.ctx.config.test_case.stop_nodes_on_exit {
+            info!("Stopping framework but keeping nodes alive...");
+            return Ok(());
+        }
+
+        info!("Stopping framework and shutting down nodes...");
 
         #[cfg(feature = "clementine")]
         {


### PR DESCRIPTION
- Optionally shutdown nodes based on new `TestCaseConfig` `stop_nodes_on_exit` value.